### PR TITLE
use Throwable instead of string representation of error

### DIFF
--- a/src/main/java/com/cucumber/listener/ExtentCucumberFormatter.java
+++ b/src/main/java/com/cucumber/listener/ExtentCucumberFormatter.java
@@ -137,7 +137,7 @@ public class ExtentCucumberFormatter implements Reporter, Formatter {
             if ("passed".equals(result.getStatus())) {
                 scenarioTest.log(LogStatus.PASS, testSteps.poll().getName(), "PASSED");
             } else if ("failed".equals(result.getStatus())) {
-                scenarioTest.log(LogStatus.FAIL, testSteps.poll().getName(), result.getErrorMessage());
+                scenarioTest.log(LogStatus.FAIL, testSteps.poll().getName(), result.getError());
             } else if ("skipped".equals(result.getStatus())) {
                 scenarioTest.log(LogStatus.SKIP, testSteps.poll().getName(), "SKIPPED");
             } else if ("undefined".equals(result.getStatus())) {


### PR DESCRIPTION
use Throwable instead of string message description as Throwable will be
logged under Exceptions view and will also be pre-formatted